### PR TITLE
Translate log level to string in production logs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ The logger's API is identical to that of pino with the following exceptions:
 
 * The property `sourcetype: _json` is added to logs in production for Splunk compatibility.
 * Lambda related environment variables are added by default:
-  * AWS_EXECUTION_ENV,
-  * AWS_LAMBDA_FUNCTION_NAME,
-  * AWS_LAMBDA_FUNCTION_MEMORY_SIZE,
-  * AWS_LAMBDA_FUNCTION_VERSION
+    * `AWS_EXECUTION_ENV`,
+    * `AWS_LAMBDA_FUNCTION_NAME`,
+    * `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`,
+    * `AWS_LAMBDA_FUNCTION_VERSION`
 * Defaults to ISO timestamp logging for splunk compatiblity. At the time of writing this incurs a 25% pino performance penalty.
 
 ### Pino properties
 
 Pino adds the following properties to logs by default:
 
-* `level` - the log level in integer form. Refer to the `pino` documentation to translate this.
+* `level` - the log level in string form. This is translated from the `pino` default of logging an integer representation.
 * `v` - the pino logger API version.
 * `hostname` - the hostname the process is running on.
 * `pid` - the process PID.

--- a/lib/__tests__/logger.test.js
+++ b/lib/__tests__/logger.test.js
@@ -1,3 +1,4 @@
+import pino from 'pino';
 import createLogger from '../logger';
 
 const setupEnv = ({ envKey, value, setter }) => {
@@ -65,7 +66,7 @@ describe('log formatting', () => {
 
     test('it logs JSON to stdout in the correct format', () => {
         const expectedLog = {
-            level: 30,
+            level: 'info',
             message: 'someMessage',
             someObject: { withNesting: true },
             sourceType: '_json',
@@ -77,6 +78,16 @@ describe('log formatting', () => {
 
         const callJson = getLogObject();
         expect(callJson).toEqual(expectedLog);
+    });
+
+    Object.keys(pino.levels.values).forEach(level => {
+        test(`it writes log level as the appropriate strings when the level is ${level}`, () => {
+            logger = createLogger();
+            logger[level]({ someObject: { withNesting: true } }, 'someMessage');
+
+            const callJson = getLogObject();
+            expect(callJson).toHaveProperty('level', level);
+        });
     });
 
     test('it includes variable properties', () => {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,24 +7,43 @@ const isLambda = () =>
         false
     );
 
+const stringifyVersion = chunk =>
+    chunk.replace(
+        /("level":\s*)(\d+)/,
+        (match, keyString, levelString) =>
+            `${keyString}"${pino.levels.labels[parseInt(levelString, 10)]}"`,
+    );
+
+const writeLog = chunk => {
+    process.stdout.write(stringifyVersion(chunk));
+};
+
+const getProductionStream = () => ({
+    write: writeLog,
+});
+
+const getPrettyPrintedStream = () => {
+    const stream = pino.pretty({ forceColor: true });
+
+    stream.pipe(process.stdout);
+    return stream;
+};
+
 const getBaseLogger = () => {
     const level = process.env.CONSOLE_LOG_LEVEL || 'trace';
+    const stream = isProduction()
+        ? getProductionStream()
+        : getPrettyPrintedStream();
 
-    let prettyPrint;
-
-    if (!isProduction()) {
-        prettyPrint = pino.pretty({ forceColor: true });
-
-        prettyPrint.pipe(process.stdout);
-    }
-
-    return pino({
-        prettyPrint,
-        level,
-        messageKey: 'message',
-        // enable ISO time stamps rather than epoch time
-        timestamp: pino.stdTimeFunctions.slowTime,
-    });
+    return pino(
+        {
+            level,
+            messageKey: 'message',
+            // enable ISO time stamps rather than epoch time
+            timestamp: pino.stdTimeFunctions.slowTime,
+        },
+        stream,
+    );
 };
 
 const getMetaData = () => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
     "@financial-times/eslint-config-de-tooling": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-de-tooling/-/eslint-config-de-tooling-2.0.3.tgz",
-      "integrity": "sha512-jp1KmoRcM3zWtAHUom65Yf4xmHM/eZWgZJMimNyADxfErKinGokpjebDvQyWqLbt9AKNuhkXZ4g6hWif2XsVAA==",
+      "integrity": "sha1-g/72uT52ta3nM10cUjF4Jf0QZDA=",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "12.1.0"
@@ -365,7 +365,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -529,7 +529,7 @@
     "babel-jest": {
       "version": "22.0.4",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.0.4.tgz",
-      "integrity": "sha512-/Yt61fUpdFjetYlnpj280BPKEsPnK4mqzxDdo8DybPvrPNrLurbAF/WBjn2nnoi1Hc2Ippsf12/aOp8ys/Vl1A==",
+      "integrity": "sha1-UzxG3jfXyddhL0CMdjFL6Sd+DCY=",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
@@ -903,7 +903,7 @@
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "integrity": "sha1-oYtWTMm5r99KrleuPBsNmRiOb0g=",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -1437,7 +1437,7 @@
     "coveralls": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
-      "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+      "integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
       "dev": true,
       "requires": {
         "js-yaml": "3.10.0",
@@ -1806,7 +1806,7 @@
     "eslint-config-prettier": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
-      "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
+      "integrity": "sha1-Xs1lF01IbCLf84n+A2/r9QLUaKM=",
       "dev": true,
       "requires": {
         "get-stdin": "5.0.1"
@@ -1857,7 +1857,7 @@
     "eslint-plugin-import": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "integrity": "sha1-+htu8x/LPFAcCYWcG4bx/FuYaJQ=",
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1",
@@ -1875,7 +1875,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1902,7 +1902,7 @@
     "eslint-plugin-prettier": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
-      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "integrity": "sha1-hcqwd1xtXjNE7wHnjZYPFm+5Oq4=",
       "dev": true,
       "requires": {
         "fast-diff": "1.1.2",
@@ -3469,7 +3469,7 @@
     "husky": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
       "dev": true,
       "requires": {
         "is-ci": "1.1.0",
@@ -4583,7 +4583,7 @@
     "lint-staged": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
-      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "integrity": "sha1-erfTRfL+MC/xlvHeagBVlKzgMhA=",
       "dev": true,
       "requires": {
         "app-root-path": "2.0.1",
@@ -5137,7 +5137,7 @@
     "microbundle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/microbundle/-/microbundle-0.2.4.tgz",
-      "integrity": "sha512-iYtgJhAjaSgPqWxkaEoC5vWvq8J5cOlrC71yq2odR9118hYBecCpgisJbd3/aobCefGBy4fl/QYW53EBNcNyDA==",
+      "integrity": "sha1-OiQUVfqpLSCpkHHyzcJ04oKhnII=",
       "dev": true,
       "requires": {
         "asyncro": "2.0.1",
@@ -5745,7 +5745,7 @@
     "pino": {
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/pino/-/pino-4.10.3.tgz",
-      "integrity": "sha512-IKXK0dcFQYITgOJBEvy1RCI5gUz+VVERXMhIvk5Ie+k9zzrbwXDs38M3H6JhoCHR58exyNpNcEKBrW4JC2P0pg==",
+      "integrity": "sha1-1GAwUk8ilP5DouIkfOGn7wKMRrw=",
       "requires": {
         "chalk": "2.3.0",
         "fast-json-parse": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@financial-times/lambda-logger",
     "version": "1.0.0",
-    "description":
-        "Logger used by the lambda team. Logs in JSON format using pino",
+    "description": "Logger used by the lambda team. Logs in JSON format using pino",
     "main": "dist/@financial-times/lambda-logger.js",
     "browser": "dist/@financial-times/lambda-logger.umd.js",
     "module": "dist/@financial-times/lambda-logger.m.js",
@@ -16,7 +15,10 @@
         "precommit": "lint-staged"
     },
     "lint-staged": {
-        "*.js": ["eslint --cache --fix", "git add"]
+        "*.js": [
+            "eslint --cache --fix",
+            "git add"
+        ]
     },
     "engines": {
         "node": ">= 6.10.0"


### PR DESCRIPTION
Level will now be a string (`info|error|...`) rather than an integer (30, 20).

This involves a regex to replace the level in the string as per https://github.com/pinojs/pino/issues/279