### PR TITLE
Added log stream name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ The logger's API is identical to that of pino with the following exceptions:
 
 * The property `sourcetype: _json` is added to logs in production for Splunk compatibility.
 * Lambda related environment variables are added by default:
-    * `AWS_EXECUTION_ENV`,
-    * `AWS_LAMBDA_FUNCTION_NAME`,
-    * `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`,
-    * `AWS_LAMBDA_FUNCTION_VERSION`
+  * `AWS_EXECUTION_ENV`,
+  * `AWS_LAMBDA_FUNCTION_NAME`,
+  * `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`,
+  * `AWS_LAMBDA_FUNCTION_VERSION`
 * Defaults to ISO timestamp logging for splunk compatiblity. At the time of writing this incurs a 25% pino performance penalty.
 
 ### Pino properties

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -56,6 +56,7 @@ const getMetaData = () => ({
               functionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
               functionMemorySize: process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE,
               functionVersion: process.env.AWS_LAMBDA_FUNCTION_VERSION,
+              logStreamName: process.env.AWS_LAMBDA_LOG_STREAM_NAME,
           }
         : undefined,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/lambda-logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This can be used to uniquely identify lambda containers (e.g. for checking re-use).

See the [environment docs](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html).