### PR TITLE
Add AWS_REGION to default lambda logs

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -57,6 +57,7 @@ const getMetaData = () => ({
     environment: process.env.ENVIRONMENT || process.env.STAGE,
     lambda: isLambda()
         ? {
+              region: process.env.AWS_REGION,
               executionEnv: process.env.AWS_EXECUTION_ENV,
               functionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
               functionMemorySize: process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE,


### PR DESCRIPTION
This is a useful debugging aid.