### PR TITLE
Add region to metadata

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -55,6 +55,7 @@ const getMetaData = () => ({
     sourceType: isProduction() ? '_json' : undefined,
     systemCode: process.env.SYSTEM_CODE,
     environment: process.env.ENVIRONMENT || process.env.STAGE,
+    region: process.env.AWS_REGION || 'unknown',
     lambda: isLambda()
         ? {
               executionEnv: process.env.AWS_EXECUTION_ENV,


### PR DESCRIPTION
open to moving it inside the `lambda` object, but this feels like a more natural and visible place to put it. 

I'm on the fence whether this should be considered a breaking change or not; any existing logs of a region property will overwrite it, but it will no longer be undefined which, I suppose, people might be relying on for something