### PR TITLE
Fix a bug for releasing process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
 
       - deploy:
           command: |
-            npm version --no-git-tag-version $(CIRCLE_TAG)
+            npm version --no-git-tag-version $CIRCLE_TAG
             npm publish --access public
 
 workflows:


### PR DESCRIPTION
Release is failed because of this error

![Screenshot 2019-11-25 at 16 18 22](https://user-images.githubusercontent.com/21194161/69557899-3f091d00-0f9f-11ea-8bcb-2e6e2ef0e84f.png)

https://circleci.com/gh/Financial-Times/lambda-logger/205

In fully automated release process commit (193e49c0ff9),
`npm version --no-git-tag-version $(CIRCLE_TAG)` line was added in circle config.yml.
Remove () to fix the bug.