### PR TITLE
update docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ references:
   container_config_node14: &container_config_node14
     working_directory: ~/project/lambda-logger
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.18.3
 
   container_config_node12: &container_config_node12
     working_directory: ~/project/lambda-logger
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12.16.3
 
   workspace_root: &workspace_root ~/project
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ references:
   container_config_node12: &container_config_node12
     working_directory: ~/project/lambda-logger
     docker:
-      - image: cimg/node:12.16.3
+      - image: cimg/node:12.22.9
 
   workspace_root: &workspace_root ~/project
 


### PR DESCRIPTION
## Why?

CircleCI have deprecated `CircleCI` Docker images and now use `cimg` in their place.

## What?

I removed the `CircleCI` Docker image and replaced it with `cimg` with a full node version number.

### Anything in particular you'd like to highlight to reviewers?

No.
