### PR TITLE
update master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,4 +153,4 @@ experimental:
   notify:
     branches:
       only:
-        - master
+        - main


### PR DESCRIPTION
## Why?
Need to update CircleCI references after changing the default branch to main

## What?
replace master -> main in ci config