### PR TITLE
Update the logic that tests if the logger is used in production env or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Pino adds the following properties to logs by default:
 
 ## Configuration
 
--   `NODE_ENV` - pretty printing is enabled when `NODE_ENV !== 'production'`.
+-   `NODE_ENV` - pretty printing is enabled when value of `NODE_ENV` is not same as `p`, `prod` or `production`.
 -   `CONSOLE_LOG_LEVEL` - determines the level to log at (pinto `level` option). Defaults to `info`.
 -   `SYSTEM_CODE` - adds the `systemCode` property to every log.
 -   `ENVIRONMENT|STAGE` - adds the `environment` property to every log. `STAGE` is used as a fallback due to it's default definition in the [serverless](https://serverless.com) framework.

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,8 @@
 import pino from 'pino';
 
-const isProduction = () => process.env.NODE_ENV === 'production';
+const prodTerms = ['production', 'prod', 'p'];
+const env = process.env.NODE_ENV; 
+const isProduction = () => prodTerms.includes(env && env.toLowerCase());
 const isLambda = () =>
 	!!(
 		(process.env.LAMBDA_TASK_ROOT && process.env.AWS_EXECUTION_ENV) ||

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,7 +1,7 @@
 import pino from 'pino';
 
 const prodTerms = ['production', 'prod', 'p'];
-const env = process.env.NODE_ENV; 
+const env = process.env.NODE_ENV;
 const isProduction = () => prodTerms.includes(env && env.toLowerCase());
 const isLambda = () =>
 	!!(

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,8 +1,7 @@
 import pino from 'pino';
 
 const prodTerms = ['production', 'prod', 'p'];
-const env = process.env.NODE_ENV;
-const isProduction = () => prodTerms.includes(env && env.toLowerCase());
+const isProduction = () => prodTerms.includes(process.env.NODE_ENV);
 const isLambda = () =>
 	!!(
 		(process.env.LAMBDA_TASK_ROOT && process.env.AWS_EXECUTION_ENV) ||


### PR DESCRIPTION
## Why?

-   The logs in Cloudwatch and Splunk don't display as `json` objects if you set the value of `NODE_ENV` any other term which represent production environments such as `prod` or `p` which we usually use in different systems

## What?

-  Allows other terms (`prod` and `p`) to be used in the logic that checks if the environment the system is running in production or not
- Updates read me

### Anything in particular you'd like to highlight to reviewers?
The `isProduction` logic only makes logs to appear as json only if the app is running in production environment and, as a result, [Splunk](https://financialtimes.splunkcloud.com/en-GB/app/search/search?q=search%20index%3Daws_cloudwatch_dev%20source%3D%2Faws%2Flambda%2Fbiz-ops-metrics-api*&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-1h&latest=now&display.events.type=table&sid=1677834404.10695428) logs as well as [Cloudwatch](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fbiz-ops-metrics-api-test-read-bulk-metric/log-events/2023$252F03$252F03$252F$255B$2524LATEST$255D37614cda2db848c6baa0ce4f931a2971) logs in test environment are not formatted as json and this makes it hard to filter out logs. I suggest we should change the logic to only not format the logs as json if the app is running in `dev`(local) environment. I would like to hear what your thought on this suggestion is 
