### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# This library is deprecated please use [DotCom logger](https://github.com/Financial-Times/dotcom-reliability-kit) instead
+# ⚠️ This library is deprecated please use [DotCom logger](https://github.com/Financial-Times/dotcom-reliability-kit) instead ⚠️
 
 # lambda-logger
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This library is deprecated please use [DotCom logger](https://github.com/Financial-Times/dotcom-reliability-kit) instead
+
 # lambda-logger
 
 Logger useful for AWS lambda applications, particularly those which are aggregated in Splunk. Logs in JSON format using [pino](https://github.com/pinojs/pino).


### PR DESCRIPTION
## Why?

-   This library has been replaced by the DotCom logger https://www.npmjs.com/package/@dotcom-reliability-kit/logger

## What?

-  Provide a deprecation notice on the readme

### Anything in particular you'd like to highlight to reviewers?
- Once merged I will trigger deprecation of the module in NPM and archive the repo